### PR TITLE
REP-1083: skip enrichment and filtering when logline has errors

### DIFF
--- a/bin/addIdentifierMIR.php
+++ b/bin/addIdentifierMIR.php
@@ -27,7 +27,9 @@ while (!feof(STDIN)) {
     if ($line = trim(fgets(STDIN))) {
         $logline = new epusta\ePuStaLogline();
         if ($epuStaLoglineParser->parse($line, $logline)) {
-            $mirToolbox->addIdentifier($logline);
+            if (!$logline->hasErrors()) {
+                $mirToolbox->addIdentifier($logline);
+            }
             echo($logline . "\n");
         } else {
             // die("Error: malformed Logline" . $line . "\n")

--- a/bin/addIdentifierOpus4.php
+++ b/bin/addIdentifierOpus4.php
@@ -29,7 +29,9 @@ while (!feof(STDIN)) {
     if ($line = trim(fgets(STDIN))) {
         $logline = new epusta\ePuStaLogline();
         if ($epuStaLoglineParser->parse($line, $logline)) {
-            $opusToolbox->addIdentifier($logline, $prefix);
+            if (!$logline->hasErrors()) {
+                $opusToolbox->addIdentifier($logline, $prefix);
+            }
             echo($logline . "\n");
         } else {
             // die("Error: malformed Logline" . $line . "\n")

--- a/bin/filter.php
+++ b/bin/filter.php
@@ -30,10 +30,12 @@ while (!feof(STDIN)) {
     if ($line = trim(fgets(STDIN))) {
         $logline = new epusta\ePuStaLogline();
         if ($epuStaLoglineParser->parse($line, $logline)) {
-            $filterRobots->edit($logline);
-            $counter3Filter30sek->edit($logline);
-            $filterHttpStatus->edit($logline);
-            $filterHttpMethod->edit($logline);
+            if (!$logline->hasErrors()) {
+                $filterRobots->edit($logline);
+                $counter3Filter30sek->edit($logline);
+                $filterHttpStatus->edit($logline);
+                $filterHttpMethod->edit($logline);
+            }
             echo($logline . "\n");
         } else {
             // die("Error: malformed Logline" . $line . "\n")

--- a/php/src/ePuStaLogline.php
+++ b/php/src/ePuStaLogline.php
@@ -26,6 +26,11 @@ class ePuStaLogline
         return $str;
     }
 
+    public function hasErrors(): bool
+    {
+        return !empty($this->errors);
+    }
+
     public function convertLogline($line)
     {
         $out = $this->uuid . " ";


### PR DESCRIPTION
Add hasErrors() method to ePuStaLogline and use it in addIdentifierMIR, addIdentifierOpus4 and filter to prevent processing of erroneous log lines.