### PR TITLE
EPUSTA-6: remove hardcoded metadata directory from getFilePathById

### DIFF
--- a/config/config.phpunit.ini
+++ b/config/config.phpunit.ini
@@ -4,5 +4,5 @@ oldMirLogs = false
 ; get-method for metadata (file - access datadir, http - uses recive and Restapi)
 getmethod = file
 ; Datadir - location of XML metadata
-;datadir = C:\Ecplise\eclipse-workspace\ePuSta-logfileparser\php\test\ressources\mirobjects
-datadir = ./php/test/ressources/mirobjects
+;datadir = C:\Ecplise\eclipse-workspace\ePuSta-logfileparser\php\test\ressources\mirobjects\metadata
+datadir = ./php/test/ressources/mirobjects/metadata

--- a/php/src/mir/AbstractFactory.php
+++ b/php/src/mir/AbstractFactory.php
@@ -15,12 +15,12 @@ abstract class AbstractFactory
             $type = $match[2];
             $dig4 = $match[3];
             $dig2 = $match[4];
-            return "metadata/" . $project . "/" . $type . "/" . $dig4 . "/" . $dig2;
+            return $project . "/" . $type . "/" . $dig4 . "/" . $dig2;
         } else if (preg_match('/([^\/]+)_([^\/]+)_([0-9]{1,2})[0-9]{2}$/', $id, $match)) {
             $project = $match[1];
             $type = $match[2];
             $dig2 = $match[3];
-            return "metadata/" . $project . "/" . $type . "/" . $dig2;
+            return $project . "/" . $type . "/" . $dig2;
         } else {
             return null;
         }


### PR DESCRIPTION
## Summary

- `AbstractFactory::getFilePathById()` gibt nicht mehr `metadata/` als fest kodierten Präfix zurück — nur noch den ID-basierten Pfad (`project/type/dig4/dig2`)
- `datadir` in der Konfiguration muss nun direkt auf das Metadaten-Verzeichnis zeigen (z.B. `/pfad/zu/mirobjects/metadata`)
- `config.phpunit.ini` entsprechend angepasst

## Migration bestehender Konfigurationen

Alle produktiven Konfigurationen müssen den `datadir`-Wert um das `metadata`-Unterverzeichnis erweitern:

```ini
; vorher
datadir = /pfad/zu/mirobjects

; nachher
datadir = /pfad/zu/mirobjects/metadata
```

## Test plan

- [x] Alle 26 PHPUnit-Tests bestehen